### PR TITLE
Add missing plotly requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ dwave-ocean-sdk>=4.1
 matplotlib>=3.3.4
 mip>=1.15.0
 pandas==2.1.3
+plotly~=5.24
 tabulate>=0.8.9


### PR DESCRIPTION
Same bug with plotly 6 applies here https://github.com/dwave-examples/flow-shop-scheduling/issues/12