### PR TITLE
Fix MIP command line runs

### DIFF
--- a/src/job_shop_scheduler.py
+++ b/src/job_shop_scheduler.py
@@ -309,12 +309,12 @@ class JobShopSchedulingCQM:
             warnings.warn("Warning: MIP did not find feasible solution")
             return
         best_sol = sol.first.sample
+        self.completion_time = best_sol["makespan"]
 
-        for var, val in best_sol.items():
-
-            if var.startswith("x"):
-                job, machine = var[1:].split("_")
+        for job in self.model_data.jobs:
+            for machine in self.model_data.resources:
                 task = self.model_data.get_resource_job_tasks(job=job, resource=machine)
+                val = best_sol[self.x[(job, machine)].variables[0]]
                 self.solution[(job, machine)] = task, val, task.duration
 
     def solution_as_dataframe(self) -> pd.DataFrame:


### PR DESCRIPTION
### Feature Implemented/Bugs Fixed
Noticed a bug with command line runs of MIP
Can be recreated by running something like `python src/job_shop_scheduler.py -s mip -i input/instance3_3.txt`
The issue was a mismatch between str and int resource numbers.

### AI Generation Disclosure
Claude was given the traceback and implemented the fix. It has been tested and reviewed by me.
